### PR TITLE
Remove duplicated code

### DIFF
--- a/countries/universal.js
+++ b/countries/universal.js
@@ -1377,7 +1377,7 @@ const universalCountries = [
     name: "Antarctic Flyover",
     code: "Antarctic Flyover",
     country_code: "ANF",
-    two_letter_country_code: "AU",
+    two_letter_country_code: undefined,
   },
   {
     name: "Caroline Islands",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-insurance-countries",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
"Antarctic Flyover" was using a same two-letter country code with Australia, this will cause mismapping when we map 'AU' back to country name

It's safe to remove, because we don't have "Antarctic Flyover" record in svc-offer database