### PR TITLE
[KAN-1260] Fix ISO country code for 'Australian Waters (cruises)'

### DIFF
--- a/countries/universal.js
+++ b/countries/universal.js
@@ -87,7 +87,7 @@ const universalCountries = [
     name: "Australian Waters (cruises)",
     code: "Australian Waters",
     country_code: "AUW",
-    two_letter_country_code: "undefined",
+    two_letter_country_code: "AU",
   },
   {
     name: "Azerbaijan",

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function getNameByCode(code) {
   return country ? country.name : undefined;
 }
 
-function getNameByTwoLetterCode() {
+function getNameByTwoLetterCode(code) {
   var country = countries.find(function (c) {
     return c.two_letter_country_code === code;
   });

--- a/index.js
+++ b/index.js
@@ -45,6 +45,14 @@ function getNameByCode(code) {
   return country ? country.name : undefined;
 }
 
+function getNameByTwoLetterCode() {
+  var country = countries.find(function (c) {
+    return c.two_letter_country_code === code;
+  });
+
+  return country ? country.name : undefined;
+}
+
 function getTwoLetterCodeByName(name) {
   var country = countries.find(function (c) {
     return c.name === name;
@@ -62,5 +70,6 @@ module.exports = {
   getNibNames,
   getCodeByName,
   getNameByCode,
+  getNameByTwoLetterCode,
   getTwoLetterCodeByName,
 };

--- a/index.js
+++ b/index.js
@@ -2,9 +2,10 @@
 const cgSpecificCountries = require("./countries/coverGenius");
 const universalCountries = require("./countries/universal");
 
-const countries = universalCountries
-  .concat(nibSpecificCountries)
-  .concat(cgSpecificCountries);
+// The order matters here - be careful
+const countries = nibSpecificCountries
+  .concat(cgSpecificCountries)
+  .concat(universalCountries);
 
 const cgCountries = universalCountries.concat(cgSpecificCountries);
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-﻿﻿const nibSpecificCountries = require("./countries/nib");
+﻿const nibSpecificCountries = require("./countries/nib");
 const cgSpecificCountries = require("./countries/coverGenius");
 const universalCountries = require("./countries/universal");
 

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,55 @@
+﻿const {
+  getCodeByName,
+  getNameByCode,
+  getNameByTwoLetterCode,
+  getTwoLetterCodeByName
+} = require('./index.js');
+
+describe('getCodeByName', () => {
+  it('should return "Australian Waters" code for "Australian Waters (cruises)" country', function() {
+    const countryName = 'Australian Waters (cruises)';
+
+    const code = getCodeByName(countryName)
+
+    expect(code).toEqual("Australian Waters")
+  });
+});
+
+describe('getNameByCode', () => {
+  it('should return "Australian Waters (cruises)" name for "Australian Waters" country', function() {
+    const countryCode = 'Australian Waters';
+
+    const name = getNameByCode(countryCode)
+
+    expect(name).toEqual("Australian Waters (cruises)")
+  });
+});
+
+describe('getNameByTwoLetterCode', () => {
+  it('should return "Australia" name by "AU" iso code', function() {
+    const countryIsoCode = 'AU';
+
+    const name = getNameByTwoLetterCode(countryIsoCode)
+
+    expect(name).toEqual("Australia")
+  });
+});
+
+describe('getTwoLetterCodeByName', () => {
+  it('should return "AU" iso code by "Australia"', function() {
+    const countryName = 'Australia';
+
+    const isoCode = getTwoLetterCodeByName(countryName)
+
+    expect(isoCode).toEqual("AU")
+  });
+
+  it('should return "AU" iso code by "Australian Waters (cruises)"', function() {
+    const countryName = 'Australia';
+
+    const isoCode = getTwoLetterCodeByName(countryName)
+
+    expect(isoCode).toEqual("AU")
+  });
+});
+

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "4.5.0",
   "description": "",
   "main": "index.js",
+  "scripts": {
+    "test": "./node_modules/.bin/jest"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/brandsexclusive/lib-insurance-countries.git"
@@ -12,5 +15,8 @@
   "bugs": {
     "url": "https://github.com/brandsexclusive/lib-insurance-countries/issues"
   },
-  "homepage": "https://github.com/brandsexclusive/lib-insurance-countries#readme"
+  "homepage": "https://github.com/brandsexclusive/lib-insurance-countries#readme",
+  "devDependencies": {
+    "jest": "^27.0.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-insurance-countries",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
We have a country code error from **cover genius** insurance provider once trying to submit cruises for _Australian Waters (cruises)_

<img width="694" alt="Checkout - Luxury Escapes 2021-06-07 23-27-48" src="https://user-images.githubusercontent.com/1470235/121083585-4a6e1300-c7e8-11eb-80a3-fea44ac7b418.png">

The issue related to this code in the `svc-insurance` repo:
https://github.com/lux-group/svc-insurance/blob/c1a1ee14099d18389ce9e08aafcc109b085e1b61/src/api/context/quote/cg/create.js#L9-L12